### PR TITLE
Update command to run on drupal:config:import

### DIFF
--- a/src/Blt/Plugin/Commands/CohesionCommands.php
+++ b/src/Blt/Plugin/Commands/CohesionCommands.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Event\ConsoleCommandEvent;
 class CohesionCommands extends BltTasks {
 
   /**
-   * @hook post-command drupal:update
+   * @hook post-command drupal:config:import
    */
   public function postCommand($result, CommandData $commandData)
   {
@@ -22,11 +22,19 @@ class CohesionCommands extends BltTasks {
       ->run();
 
     if(trim($result->getMessage()) === "Enabled") {
+      // Import cohesion assets from the API.
       $result = $this->taskDrush()
         ->stopOnFail()
         ->drush("cohesion:import")
         ->run();
 
+      // Import cohesion configuration from the sync folder.
+      $result = $this->taskDrush()
+        ->stopOnFail()
+        ->drush("sync:import --overwrite-all")
+        ->run();
+
+      // Rebuild Cohesion.
       $result = $this->taskDrush()
         ->stopOnFail()
         ->drush("cohesion:rebuild")


### PR DESCRIPTION
drupal:update is not part of "blt setup". As such cohesion config is not imported on blt setup.

Switch the command to run after drupal:config:import instead. 

Also add "sync:import" to the cohesion commands to be executed to bring in any local cohesion configuration.
