### PR TITLE
Rebuild cache before attempting cohesion import.

### DIFF
--- a/src/Blt/Plugin/Commands/CohesionCommands.php
+++ b/src/Blt/Plugin/Commands/CohesionCommands.php
@@ -22,6 +22,13 @@ class CohesionCommands extends BltTasks {
       ->run();
 
     if(trim($result->getMessage()) === "Enabled") {
+      // Rebuild cache.
+      $result = $this->taskDrush()
+        ->stopOnFail()
+        ->alias("self")
+        ->drush("cr")
+        ->run();
+
       // Import cohesion assets from the API.
       $result = $this->taskDrush()
         ->stopOnFail()


### PR DESCRIPTION
We need to rebuild cache before cohesion import, or else

```
In EntityTypeRepository.php line 98:

  The Drupal\cohesion_website_settings\Entity\WebsiteSettings class does not correspond to an entity type.
```
